### PR TITLE
Error toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ const tpl = require('tpl-php');
 
 tpl('my-template.tpl.php', { name: 'Alasdair' })
 .then(rendered => console.log(rendered)); // <h1>Good morning, Alasdair</h1>
+
+// if the template executes with errors, you can toggle whether they're shown in the output or not
+tpl('my-template.tpl.php', { name: 'Alasdair' }, { showErrors: true });
 ```
 
 ### Development

--- a/index.js
+++ b/index.js
@@ -5,14 +5,17 @@ const exec = require('child_process').exec;
  *
  * @param      {string}   filePath  The absolute path to the tpl.php
  * @param      {object}   context   The context, which will become $variables in the template
+ * @param      {object}   options   Options (currently only one, boolean shouldShowErrors [default: true] to toggle baked-in PHP errors)
  * @return     {Promise}  a Promise which resolves to the rendered HTML
  */
-const render = function(filePath, context = {}) {
+const render = function(filePath, context = {}, options) {
   if (!/\.tpl\.php$/.test(filePath)) {
     return new Promise((res, rej) => rej(`File must have the .tpl.php extension. Filename is: ${filePath}`));
   }
 
-  const cmd = `php ${__dirname}/transformer.php ${filePath} '${JSON.stringify(context)}'`;
+  const { showErrors } = options || {};
+
+  const cmd = `php ${__dirname}/transformer.php ${filePath} '${JSON.stringify(context)}' ${showErrors || true}`;
 
   return new Promise((resolve, reject) => {
     exec(cmd, (err, stdout, stderr) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpl-php",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Renderer for Drupal 7 .tpl.php files for use with pattern libraries",
   "main": "index.js",
   "scripts": {

--- a/spec/renderSpec.js
+++ b/spec/renderSpec.js
@@ -17,6 +17,14 @@ describe('tpl-php render function', () => {
     });
   });
 
+  it('also works using the $context variable (for Drupal Paragraphs)', done => {
+    tpl('./spec/tpl/paragraph.tpl.php', { name: 'Paragraph' })
+    .then(rendered => {
+      expect(rendered).toBe('<h1>Hello, Paragraph</h1>\n');
+      done();
+    });
+  })
+
   it('renders lists of items', done => {
     const ctx = {
       todos: ['write tests', 'publish to npm', 'rejoice']

--- a/spec/renderSpec.js
+++ b/spec/renderSpec.js
@@ -17,7 +17,7 @@ describe('tpl-php render function', () => {
     });
   });
 
-  it('also works using the $context variable (for Drupal Paragraphs)', done => {
+  it('also works using the $content variable (for Drupal Paragraphs)', done => {
     tpl('./spec/tpl/paragraph.tpl.php', { name: 'Paragraph' })
     .then(rendered => {
       expect(rendered).toBe('<h1>Hello, Paragraph</h1>\n');

--- a/spec/renderSpec.js
+++ b/spec/renderSpec.js
@@ -36,7 +36,6 @@ describe('tpl-php render function', () => {
       done();
     })
     .catch(err => {
-      console.log(err);
       done.fail();
     })
   });

--- a/spec/tpl/paragraph.tpl.php
+++ b/spec/tpl/paragraph.tpl.php
@@ -1,0 +1,1 @@
+<h1>Hello, <?php print $content['name'] ?></h1>

--- a/spec/tpl/with_error.tpl.php
+++ b/spec/tpl/with_error.tpl.php
@@ -1,0 +1,1 @@
+<p><?php print $variables['nonexistent_variable'] ?></p>

--- a/transformer.php
+++ b/transformer.php
@@ -3,5 +3,6 @@ $tpl = $argv[1];
 $file = file_get_contents($tpl);
 
 $variables = json_decode($argv[2], true);
+$content = $variables;
 eval("?>$file");
 ?>

--- a/transformer.php
+++ b/transformer.php
@@ -1,8 +1,21 @@
 <?php
-$tpl = $argv[1];
-$file = file_get_contents($tpl);
-
+// we prefix our variables with tpl_php_ so they hopefully don't clash with template vars
+$tpl_php_show_err = $argv[3] === 'true';
+// set error reporting vars if needed
+if ($tpl_php_show_err) {
+  ini_set('display_errors', 1);
+  ini_set('display_startup_errors', 1);
+}
+else {
+  ini_set('display_errors', 0);
+  ini_set('display_startup_errors', 0);
+}
+// get the template code
+$tpl_php_tpl = $argv[1];
+$tpl_php_file = file_get_contents($tpl_php_tpl);
+// parse variables
 $variables = json_decode($argv[2], true);
 $content = $variables;
-eval("?>$file");
+// execute template
+eval("?>$tpl_php_file");
 ?>


### PR DESCRIPTION
This updates the repo to version 0.2.0.

Additions:

+ `$variables` are now also copied to `$content` for convenience
+ `render` now accepts an `options` object as the last parameter
+ there is now a single option, `showErrors`, which is a `Boolean` toggling whether PHP errors appear in the template